### PR TITLE
Use OpenAI embeddings

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,13 +4,14 @@ from fastapi import FastAPI, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from ingest.pdf_ingest import load_pdf, chunk_text
 from embeddings.vector_store import VectorStore
-from sentence_transformers import SentenceTransformer
 from config import EMBEDDING_MODEL_NAME
 from retrieval.qa_chain import answer as rag_answer, reset_chat_history
 import os
+import openai
 
 from dotenv import load_dotenv
 load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI(title="Groupon RAG Backend", description="Conversational RAG with Qdrant & GPT", version="1.0")
 
@@ -23,8 +24,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Load embedding model + vector store once at startup
-model = SentenceTransformer(EMBEDDING_MODEL_NAME)
+# Load vector store once at startup
 vector_store = VectorStore()
 
 @app.post("/upload")
@@ -37,10 +37,14 @@ async def upload_doc(file: UploadFile = File(...)):
 
     text = load_pdf(file_path)
     chunks = chunk_text(text)
-    embeddings = model.encode(chunks)
+    response = openai.embeddings.create(
+        model=EMBEDDING_MODEL_NAME,
+        input=chunks
+    )
+    embeddings = [d.embedding for d in response.data]
 
     # Cloud safe collection create
-    vector_store.create_collection_if_not_exists(vector_size=embeddings.shape[1])
+    vector_store.create_collection_if_not_exists(vector_size=len(embeddings[0]))
     metadatas = [{"text": chunk, "source": file.filename} for chunk in chunks]
     vector_store.upsert_embeddings(embeddings, metadatas)
 

--- a/config.py
+++ b/config.py
@@ -5,5 +5,7 @@ load_dotenv()
 QDRANT_URL = os.getenv("QDRANT_URL")
 QDRANT_API_KEY = os.getenv("QDRANT_API_KEY")
 
-EMBEDDING_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+EMBEDDING_MODEL_NAME = os.getenv(
+    "OPENAI_EMBEDDING_MODEL", "text-embedding-3-small"
+)
 COLLECTION_NAME = "groupon_docs"

--- a/embeddings/embed.py
+++ b/embeddings/embed.py
@@ -2,9 +2,12 @@
 
 from ingest.pdf_ingest import load_pdf, chunk_text
 from embeddings.vector_store import VectorStore
-from sentence_transformers import SentenceTransformer
 from config import EMBEDDING_MODEL_NAME
 import os
+import openai
+from dotenv import load_dotenv
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 def main():
     pdf_path = "sample_docs/sample.pdf"
@@ -13,11 +16,14 @@ def main():
 
     print(f"Loaded {len(chunks)} chunks from PDF.")
 
-    model = SentenceTransformer(EMBEDDING_MODEL_NAME)
-    embeddings = model.encode(chunks)
+    response = openai.embeddings.create(
+        model=EMBEDDING_MODEL_NAME,
+        input=chunks
+    )
+    embeddings = [d.embedding for d in response.data]
 
     vector_store = VectorStore()
-    vector_store.create_collection(vector_size=embeddings.shape[1])
+    vector_store.create_collection(vector_size=len(embeddings[0]))
 
     metadatas = [{"text": chunk, "source": os.path.basename(pdf_path)} for chunk in chunks]
     vector_store.upsert_embeddings(embeddings, metadatas)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-
 fastapi
 uvicorn
 langchain
 langchain_community
-sentence-transformers
 qdrant-client
 openai
 python-dotenv

--- a/retrieval/qa_chain.py
+++ b/retrieval/qa_chain.py
@@ -2,7 +2,6 @@
 
 from embeddings.vector_store import VectorStore
 from config import EMBEDDING_MODEL_NAME
-from sentence_transformers import SentenceTransformer
 import openai
 import os
 from dotenv import load_dotenv
@@ -11,7 +10,6 @@ load_dotenv()
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
-model = SentenceTransformer(EMBEDDING_MODEL_NAME)
 vector_store = VectorStore()
 
 # Global chat history (per session, in-memory)
@@ -43,7 +41,11 @@ Answer:
 
 def answer(query, top_k=5):
     # Embed query
-    query_embedding = model.encode([query])[0]
+    response = openai.embeddings.create(
+        model=EMBEDDING_MODEL_NAME,
+        input=[query]
+    )
+    query_embedding = response.data[0].embedding
 
     # Search in Qdrant
     hits = vector_store.search(query_embedding, top_k=top_k)


### PR DESCRIPTION
## Summary
- switch to OpenAI embedding API to avoid loading local models
- update app, embed script, and retrieval chain accordingly
- drop `sentence-transformers` from requirements
- configure default embedding model in `config.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844b46d2b1483269fd85f7a3bcd14e3