### PR TITLE
Add OpenAI Assistants support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A FastAPI-based backend implementing RAG (Retrieval-Augmented Generation) for in
 - **CORS Support**: Configured for frontend integration
 - **Interactive API Docs**: Swagger UI at `/docs`
 - **Chat Memory**: Conversation context management
+- **OpenAI Assistants API**: Threads with Qdrant-powered context
 
 ## 🛠️ Tech Stack
 
@@ -62,6 +63,35 @@ Reset the conversation history.
 }
 ```
 
+#### `POST /assistant-search`
+Query using the OpenAI Assistants API with additional context fetched from Qdrant.
+
+**Request Body:**
+```json
+{
+  "query": "string"
+}
+```
+
+**Response:**
+```json
+{
+  "answer": "AI-generated response",
+  "assistant_id": "assistant_123",
+  "thread_id": "thread_456"
+}
+```
+
+#### `POST /assistant-reset`
+Start a new assistant thread.
+
+**Response:**
+```json
+{
+  "message": "Assistant thread reset"
+}
+```
+
 #### `GET /docs`
 Interactive API documentation (Swagger UI)
 
@@ -98,6 +128,8 @@ Create a `.env` file in the backend directory:
 ```env
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key
+# Optional: reuse an existing assistant ID
+OPENAI_ASSISTANT_ID=assistant_123
 
 # Qdrant Configuration (Cloud)
 QDRANT_URL=https://your-cluster-url.qdrant.tech

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from ingest.pdf_ingest import load_pdf, chunk_text
 from embeddings.vector_store import VectorStore
 from config import EMBEDDING_MODEL_NAME
 from retrieval.qa_chain import answer as rag_answer, reset_chat_history
+from retrieval.openai_assistant import answer as assistant_answer, reset_thread
 import os
 import openai
 
@@ -61,7 +62,20 @@ async def search_query(query: str):
     result = rag_answer(query)
     return result
 
+
+@app.post("/assistant-search")
+async def assistant_search(query: str):
+    """Use OpenAI's Assistants API to handle the conversation."""
+    result = assistant_answer(query)
+    return result
+
 @app.post("/reset-chat")
 async def reset_chat():
     reset_chat_history()
     return {"status": "success", "message": "Chat history cleared."}
+
+
+@app.post("/assistant-reset")
+async def assistant_reset():
+    reset_thread()
+    return {"status": "success", "message": "Assistant thread reset."}

--- a/retrieval/openai_assistant.py
+++ b/retrieval/openai_assistant.py
@@ -1,0 +1,98 @@
+import os
+import time
+import openai
+from dotenv import load_dotenv
+
+from embeddings.vector_store import VectorStore
+from config import EMBEDDING_MODEL_NAME
+from retrieval.qa_chain import build_context_from_sources
+
+load_dotenv()
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+# Global assistant and thread identifiers
+assistant_id = os.getenv("OPENAI_ASSISTANT_ID")
+_thread_id = None
+vector_store = VectorStore()
+
+
+def _ensure_assistant():
+    """Create an assistant if none exists."""
+    global assistant_id
+    if assistant_id:
+        return assistant_id
+
+    assistant = openai.beta.assistants.create(
+        name="Groupon Assistant",
+        instructions=(
+            "You are a helpful assistant for Groupon engineers."
+            " Use any provided context from Qdrant as the primary source"
+            " for answers. If you do not know an answer, say so."
+        ),
+        model="gpt-4o",
+    )
+    assistant_id = assistant.id
+    return assistant_id
+
+
+def _ensure_thread():
+    """Create a thread if none exists."""
+    global _thread_id
+    if _thread_id is None:
+        thread = openai.beta.threads.create()
+        _thread_id = thread.id
+    return _thread_id
+
+
+def answer(query: str, top_k: int = 5) -> dict:
+    """Retrieve context from Qdrant and ask the assistant."""
+    aid = _ensure_assistant()
+    tid = _ensure_thread()
+
+    # Retrieve context from Qdrant
+    embedding = openai.embeddings.create(
+        model=EMBEDDING_MODEL_NAME,
+        input=[query],
+    ).data[0].embedding
+    hits = vector_store.search(embedding, top_k=top_k)
+    context = build_context_from_sources(hits)
+
+    user_msg = f"Question: {query}\n\nContext:\n{context}"
+
+    openai.beta.threads.messages.create(
+        thread_id=tid,
+        role="user",
+        content=user_msg,
+    )
+
+    run = openai.beta.threads.runs.create(
+        thread_id=tid,
+        assistant_id=aid,
+    )
+
+    # Poll until run is complete
+    while True:
+        run_status = openai.beta.threads.runs.retrieve(
+            thread_id=tid, run_id=run.id
+        )
+        if run_status.status == "completed":
+            break
+        if run_status.status in {"failed", "cancelled", "expired"}:
+            raise RuntimeError(f"Run {run_status.status}")
+        time.sleep(0.5)
+
+    messages = openai.beta.threads.messages.list(thread_id=tid)
+    for msg in messages.data:
+        if msg.role == "assistant":
+            answer_text = msg.content[0].text.value
+            break
+    else:
+        answer_text = ""
+
+    return {"answer": answer_text, "assistant_id": aid, "thread_id": tid}
+
+
+def reset_thread() -> None:
+    """Start a new thread for a fresh conversation."""
+    global _thread_id
+    _thread_id = None


### PR DESCRIPTION
## Summary
- integrate OpenAI Assistants API and expose new endpoints
- document new endpoints using Assistants
- fetch context from Qdrant before sending queries to Assistants

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684951293914832694e2a3716c95bb29